### PR TITLE
Update mpl_pboc.py

### DIFF
--- a/src/tregs/mpl_pboc.py
+++ b/src/tregs/mpl_pboc.py
@@ -23,7 +23,7 @@ def plotting_style(grid=False):
       Returns a dictionary of the standard PBoC 2e color palette. 
     """
     rc = {'axes.facecolor': '#E3DCD0',
-          'font.family': 'Lucida Sans Unicode',
+          'font.family': 'DejaVu Sans',
           'grid.linestyle': '-',
           'grid.linewidth': 0.5,
           'grid.alpha': 0.75,


### PR DESCRIPTION
TL;DR:  
Replace all uses of 'Lucida Sans Unicode' with 'DejaVu Sans' to eliminate Matplotlib font warnings and ensure compatibility across systems.

---

Verbose explanation:

- The plotting style in theoretical_regseq/src/tregs/mpl_pboc.py previously set 'font.family': 'Lucida Sans Unicode'.
- This font is not available by default on most Linux and macOS systems, leading to repeated Matplotlib warnings:  
  findfont: Font family 'Lucida Sans Unicode' not found.
- These warnings clutter output and can obscure real errors.
- The codebase already uses 'DejaVu Sans' as the default font elsewhere, which is the standard Matplotlib font and is available on all platforms.
- This commit changes the plotting style to use 'DejaVu Sans' instead, ensuring consistent appearance and eliminating the warnings.
- No visual changes to plots are expected, but the code is now more portable and user-friendly.